### PR TITLE
fix: need convert() string to_date() on oracle 11g! should type host …

### DIFF
--- a/Oracle-ArchiveLog-Analyzer.pl
+++ b/Oracle-ArchiveLog-Analyzer.pl
@@ -77,8 +77,8 @@ sub Main {
   my $chackusers= $checkuser ? " AND  USERNAME in ($checkuser)  " : "";
   $addsql=$addsql." AND START_SCN >= $startpos " if($startpos);
   $addsql=$addsql." AND COMMIT_SCN <= $stoppos " if($stoppos);
-  $addsql=$addsql." AND START_TIMESTAMP  >= '$startdate' " if($startdate);
-  $addsql=$addsql." AND COMMIT_TIMESTAMP <= '$stopdate' " if($stopdate);
+  $addsql=$addsql." AND START_TIMESTAMP  >= TO_DATE('$startdate', 'yyyy/mm/dd hh24:mi:ss') " if($startdate);
+  $addsql=$addsql." AND COMMIT_TIMESTAMP <= TO_DATE('$stopdate', 'yyyy/mm/dd hh24:mi:ss') " if($stopdate);
   $addsql=$addsql." AND TABLE_NAME in ($table) " if($table);
   $addsql=$addsql." AND xid='$in_xid' " if($in_xid);
   my $getsql=qq{

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ perl Oracle-ArchiveLog-Analyzer.pl
 ```
 
 ```
-$ perl Oracle-ArchiveLog-Analyzer.pl  --sid orcl --pass xxxx --checkuser "'ORAUSER'" --start-datetime '2016/02/18 14:41:27' --stop-datetime '2016/02/18 15:05:00'  /opt/app/oracle/online-redo/redo02.log
+$ perl Oracle-ArchiveLog-Analyzer.pl  --sid orcl --host 127.0.0.1 --pass xxxx --checkuser "'ORAUSER'" --start-datetime '2016/02/18 14:41:27' --stop-datetime '2016/02/18 15:05:00'  /opt/app/oracle/online-redo/redo02.log
 
 -- START_TIME: 2016/02/18 14:41:27    COMMIT_TIME: 2016/02/18 14:41:42
 -- START_SCN: 47902287496      COMMIT_SCN: 47902287503
@@ -71,7 +71,7 @@ truncate table TEST;
 
 Use --select to show SELECT statement.
 ```
-$ perl Oracle-ArchiveLog-Analyzer.pl  --sid orcl --pass xxxx --checkuser "'ORAUSER'" --start-datetime '2016/02/18 14:41:27' --stop-datetime '2016/02/18 15:04:53'  /opt/app/oracle/online-redo/redo02.log --select
+$ perl Oracle-ArchiveLog-Analyzer.pl  --sid orcl --host 127.0.0.1 --pass xxxx --checkuser "'ORAUSER'" --start-datetime '2016/02/18 14:41:27' --stop-datetime '2016/02/18 15:04:53'  /opt/app/oracle/online-redo/redo02.log --select
 
 
 -- START_TIME: 2016/02/18 14:41:27    COMMIT_TIME: 2016/02/18 14:41:42


### PR DESCRIPTION
some error occur on oracle 11g:
> ORA-01861: literal does not match format string (DBD ERROR: error possibly near <*> indicator at char 963 in ... '

fixbugs: 1 Need convert() string to_date() on oracle 11g
optimization:   Should type host argument.
